### PR TITLE
Update GlassCannon profile

### DIFF
--- a/ramdisk/init.profiles.rc
+++ b/ramdisk/init.profiles.rc
@@ -48,7 +48,7 @@ on property:persist.spectrum.profile=0
    write /sys/devices/system/cpu/cpu4/cpufreq/flash/go_hispeed_load 150
    write /sys/devices/system/cpu/cpu4/cpufreq/flash/above_hispeed_delay "20000 960000:40000 1248000:30000"
    write /sys/devices/system/cpu/cpu4/cpufreq/flash/timer_rate 60000
-   write /sys/devices/system/cpu/cpu4/cpufreq/flash/hispeed_freq 384000
+   write /sys/devices/system/cpu/cpu4/cpufreq/flash/hispeed_freq 960000
    write /sys/devices/system/cpu/cpu4/cpufreq/flash/timer_slack 380000
    write /sys/devices/system/cpu/cpu4/cpufreq/flash/target_loads 98
    write /sys/devices/system/cpu/cpu4/cpufreq/flash/min_sample_time 60000
@@ -64,7 +64,7 @@ on property:persist.spectrum.profile=0
    write /sys/devices/system/cpu/cpu4/cpufreq/flash/screen_off_maxfreq 864000
    # Input boost values
    write /sys/module/cpu_boost/parameters/input_boost_enabled 1
-   write /sys/module/cpu_boost/parameters/input_boost_freq "0:600000 1:600000 2:600000 3:600000 4:633600 5:633600 6:633600 7:633600"
+   write /sys/module/cpu_boost/parameters/input_boost_freq "0:600000 1:600000 2:600000 3:600000 4:960000 5:960000 6:960000 7:960000"
    write /sys/module/cpu_boost/parameters/input_boost_ms 300
    # Other values
    write /sys/module/msm_performance/parameters/touchboost 0


### PR DESCRIPTION
This fix should:
Address stutters experienced due to issues concerning both SoC 808 and SoC 810, inefficient frequency handling; probably because of aligning clusters with same frequency values (unlike previous SoC such as HH).
Provide smoother UI experience and more dynamic recents access.
Increase Multitasking fluidity caused by poor memory management for angler. If you notice some small stutters when a lot of your apps are open or you are switching tasks, that is because the big cluster isn't recognizing the heavy load post target of 150.

What do you adjust?

Just the tunables on big cluster frequency:

hispeed_frequency: 960mhz
input_boost_frequency for cpu 4-7: 960mhz