### PR TITLE
Fix Treble Check

### DIFF
--- a/anykernel.sh
+++ b/anykernel.sh
@@ -43,7 +43,7 @@ die() {
 
 
 # Don't even think about flashing on Treble
-treble=$(file_getprop /system/build.prop "ro.treble.enabled");
+treble=$(file_getprop /system/build.prop "ro.treble.enabled=true");
 if [ ! -z $treble ]; then
   die "Flash Kernel is not compatible with Treble yet!";
 fi;

--- a/anykernel.sh
+++ b/anykernel.sh
@@ -43,7 +43,7 @@ die() {
 
 
 # Don't even think about flashing on Treble
-treble=$(file_getprop /system/build.prop "ro.treble.enabled=true");
+treble=$(if [ ! -z $treble || $treble == "true" ]; then
 if [ ! -z $treble ]; then
   die "Flash Kernel is not compatible with Treble yet!";
 fi;


### PR DESCRIPTION
Some custom ROMs have the prop "ro.treble.enabled", but have it set to false. Currently, kernels fail to flash in TWRP because they fail the check, so fix it.

OmniROM Treskmod: 
OnePlus5:/ $ getprop ro.treble.enabled
false
OnePlus5:/ $

Florian in your group also couldn't flash it on LineageOS with this check in.

(I hope I did this right, apologize if not. This is my first proper PR.)